### PR TITLE
Make response returned by scanHandler JSON compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Content-Type: application/json; charset=utf-8
 Date: Mon, 28 Aug 2017 20:22:34 GMT
 Content-Length: 56
 
-{ Status: "FOUND", Description: "Eicar-Test-Signature" }
+{ "Status": "FOUND", "Description": "Eicar-Test-Signature" }
 ```
 
 **HTTPS**
@@ -65,7 +65,7 @@ Content-Type: application/json; charset=utf-8
 Date: Mon, 28 Aug 2017 20:22:34 GMT
 Content-Length: 56
 
-{ Status: "FOUND", Description: "Eicar-Test-Signature" }
+{ "Status": "FOUND", "Description": "Eicar-Test-Signature" }
 ```
 
 Test that service returns 200 for clean file:
@@ -81,7 +81,7 @@ Content-Type: application/json; charset=utf-8
 Date: Mon, 28 Aug 2017 20:23:16 GMT
 Content-Length: 33
 
-{ Status: "OK", Description: "" }
+{ "Status": "OK", "Description": "" }
 ```
 **HTTPS**
 ```bash
@@ -94,7 +94,7 @@ Content-Type: application/json; charset=utf-8
 Date: Mon, 28 Aug 2017 20:23:16 GMT
 Content-Length: 33
 
-{ Status: "OK", Description: "" }
+{ "Status": "OK", "Description": "" }
 ```
 
 

--- a/clamrest.go
+++ b/clamrest.go
@@ -115,7 +115,7 @@ func scanHandler(w http.ResponseWriter, r *http.Request) {
 			response, err := c.ScanStream(part, abort)
 			for s := range response {
 				w.Header().Set("Content-Type", "application/json; charset=utf-8")
-				respJson := fmt.Sprintf("{ Status: \"%s\", Description: \"%s\" }", s.Status, s.Description)
+				respJson := fmt.Sprintf("{ \"Status\": \"%s\", \"Description\": \"%s\" }", s.Status, s.Description)
 				switch s.Status {
 				case clamd.RES_OK:
 					w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
The response returned by scanHandler follows JSON RFC 8259 (https://www.rfc-editor.org/rfc/rfc8259.txt) by adding quotation marks around string used for object's name.