### PR TITLE
Build & push arm64 to docker hub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY_IMAGE: "${{ vars.DOCKER_USER }}/clamav-rest"
   REGISTRY_USER: ${{ vars.DOCKER_USER }}
-  REGISTRY_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}
+  REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,12 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -52,17 +58,7 @@ jobs:
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-      
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
-     
-      - name: Inspect image
-        run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}  
-
+ 
       - name: Extract metadata (tags, labels) for Docker
         id: meta_dev
         uses: docker/metadata-action@v4
@@ -96,6 +92,7 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y%m%d')"
@@ -107,12 +104,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.date.outputs.date }}
 
-      - name: Create a GitHub release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.date.outputs.date }}
-          name: Release ${{ steps.date.outputs.date }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+      # - name: Create a GitHub release
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     tag: ${{ steps.date.outputs.date }}
+      #     name: Release ${{ steps.date.outputs.date }}
+      #     body: ${{ steps.tag_version.outputs.changelog }}
 
 
   merge:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,13 +24,12 @@ jobs:
       matrix:
         platform:
           - linux/amd64
-          - linux/arm/v6
-          - linux/arm/v7
+          # - linux/arm/v6
+          # - linux/arm/v7
           - linux/arm64
 
     outputs:
-      # image_digest: ${{ steps.container_metadata.outputs.digest }}
-      image_tags: ${{ steps.meta_dev.outputs.tags }}
+      image_tags: ${{ steps.meta.outputs.tags }}
 
     steps:
       - name: Prepare
@@ -112,7 +111,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
-            type=schedule,value={{date 'YYYYMMDD'}}
+            type=raw,value={{date 'YYYYMMDD'}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
@@ -126,6 +125,13 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.date.outputs.date }}
+
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.date.outputs.date }}
+          name: Release ${{ steps.date.outputs.date }}
+          body: ${{ steps.tag_version.outputs.changelog }}
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,9 +119,9 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y%m%d')"
 
-      - name: Add version tag
+      - name: Add Github version tag 
         id: tag_version
-        uses: laputansoft/github-tag-action@v4.6
+        uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ steps.date.outputs.date }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,9 @@
 name: Build, Push Container image to DockerHub
 
-on:
-  workflow_dispatch:
-  schedule:
-    - cron: '0 0 * * 6' # At 12:00 AM, only on Saturday
+# on:
+#   # workflow_dispatch:
+#   # schedule:
+#   #   - cron: '0 0 * * 6' # At 12:00 AM, only on Saturday
 
 env:
   IMAGE_NAME: "clamav-rest"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,20 +88,6 @@ jobs:
           retention-days: 1
 
 
-      # - name: Add version tag
-      #   id: tag_version
-      #   uses: laputansoft/github-tag-action@v4.6
-      #   with:
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
-      #     tag: ${{ steps.date.outputs.date }}
-
-      # - name: Create a GitHub release
-      #   uses: ncipollo/release-action@v1
-      #   with:
-      #     tag: ${{ steps.date.outputs.date }}
-      #     name: Release ${{ steps.date.outputs.date }}
-      #     body: ${{ steps.tag_version.outputs.changelog }}
-
 
   merge:
     runs-on: ubuntu-latest
@@ -128,8 +114,8 @@ jobs:
         name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
       -
         name: Create manifest list and push
         working-directory: /tmp/digests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,8 +86,9 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          # https://github.com/docker/metadata-action?tab=readme-ov-file#typeschedule
           tags: |
-            type=raw,value={{date 'YYYYMMDD'}}
+            type=schedule,pattern={{date 'YYYYMMDD'}}
             type=raw,value=latest,enable={{is_default_branch}}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,11 +120,8 @@ jobs:
         id: date
         run: echo "::set-output name=date::$(date +'%Y%m%d')"
 
-
       - name: Add version tag
-        - name: Set up Docker Buildx
         id: tag_version
-          uses: docker/setup-buildx-action@v3
         uses: laputansoft/github-tag-action@v4.6
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
       - "main"
 env:
   IMAGE_NAME: "clamav-rest"
-  REGISTRY_IMAGE: ${{ secrets.DOCKER_USER }}/${{ env.IMAGE_NAME }}
+  REGISTRY_IMAGE: "${{ secrets.DOCKER_USER }}/clamav-rest"
   REGISTRY_USER: ${{ secrets.DOCKER_USER }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,7 @@ permissions:
   contents: write
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
     matrix:
       platform:
@@ -25,62 +23,66 @@ jobs:
         - linux/arm/v6
         - linux/arm/v7
         - linux/arm64
-      
+
     outputs:
       image_digest: ${{ steps.container_metadata.outputs.digest }}
       image_tags: ${{ steps.meta_dev.outputs.tags }}
 
     steps:
-    - name: Prepare
-    - run: |
-        platform=${{ matrix.platform }}
-        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV  
-    - name: Checkout
-    - uses: actions/checkout@v4
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: ${{ env.REGISTRY_USER }}
-        password: ${{ env.REGISTRY_PASSWORD }}
-    
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta_dev
-      uses: docker/metadata-action@v4
-      with:
-        images: ajilaag/${{ env.IMAGE_NAME }}
-        tags: |
-          type=raw,value={{date 'YYYYMMDD'}}
-          Type=raw,value=latest,enable={{is_default_branch}}
+      - name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
-    - name: Build and push to DockerHub
-      id: container_metadata
-      uses: docker/build-push-action@v5
-      with:
-        context: .
-        platforms: ${{ matrix.platform }}
-        push: true
-        tags: ${{ steps.meta_dev.outputs.tags }}
-        labels: ${{ steps.meta_dev.outputs.labels }}
-        outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-    
-    - name: Get current date
-      id: date
-      run: echo "::set-output name=date::$(date +'%Y%m%d')"
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Add version tag
-      id: tag_version
-      uses: laputansoft/github-tag-action@v4.6
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        tag: ${{ steps.date.outputs.date }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
-    - name: Create a GitHub release
-      uses: ncipollo/release-action@v1
-      with:
-        tag: ${{ steps.date.outputs.date }}
-        name: Release ${{ steps.date.outputs.date }}
-        body: ${{ steps.tag_version.outputs.changelog }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.REGISTRY_USER }}
+          password: ${{ env.REGISTRY_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta_dev
+        uses: docker/metadata-action@v4
+        with:
+          images: ajilaag/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value={{date 'YYYYMMDD'}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push to DockerHub
+        id: container_metadata
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.meta_dev.outputs.tags }}
+          labels: ${{ steps.meta_dev.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+
+      - name: Add version tag
+        id: tag_version
+        uses: laputansoft/github-tag-action@v4.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.date.outputs.date }}
+
+      - name: Create a GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.date.outputs.date }}
+          name: Release ${{ steps.date.outputs.date }}
+          body: ${{ steps.tag_version.outputs.changelog }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,8 @@ on:
     branches:
       - "main"
 env:
-  REGISTRY_IMAGE: "$DOCKER_USER_VAR/clamav-rest"
-  REGISTRY_USER: $DOCKER_USER_VAR
+  REGISTRY_IMAGE: "${{ env.DOCKER_USER_VAR }}/clamav-rest"
+  REGISTRY_USER: ${{ env.DOCKER_USER_VAR }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,16 +19,30 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    matrix:
+      platform:
+        - linux/amd64
+        - linux/arm/v6
+        - linux/arm/v7
+        - linux/arm64
       
     outputs:
       image_digest: ${{ steps.container_metadata.outputs.digest }}
       image_tags: ${{ steps.meta_dev.outputs.tags }}
 
     steps:
+    - name: Prepare
+      run: |
+        platform=${{ matrix.platform }}
+        echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV  
+    - name: Checkout
     - uses: actions/checkout@v4
-
-    - name: Log in to DockerHub
-      uses: docker/login-action@v2
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to Docker Hub
+      uses: docker/login-action@v3
       with:
         username: ${{ env.REGISTRY_USER }}
         password: ${{ env.REGISTRY_PASSWORD }}
@@ -44,12 +58,14 @@ jobs:
 
     - name: Build and push to DockerHub
       id: container_metadata
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v5
       with:
         context: .
+        platforms: ${{ matrix.platform }}
         push: true
         tags: ${{ steps.meta_dev.outputs.tags }}
         labels: ${{ steps.meta_dev.outputs.labels }}
+        outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
     
     - name: Get current date
       id: date

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,9 +9,9 @@ on:
     branches:
       - "main"
 env:
-  REGISTRY_IMAGE: "${{ vars.DOCKER_USER_VAR }}/clamav-rest"
-  REGISTRY_USER: ${{ vars.DOCKER_USER_VAR }}
-  REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+  REGISTRY_IMAGE: "${{ vars.DOCKER_USER }}/clamav-rest"
+  REGISTRY_USER: ${{ vars.DOCKER_USER }}
+  REGISTRY_PASSWORD: "${{ secrets.DOCKER_PASSWORD }}
 
 permissions:
   contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,6 @@ on:
     branches:
       - "main"
 env:
-  IMAGE_NAME: "clamav-rest"
   REGISTRY_IMAGE: "${{ secrets.DOCKER_USER }}/clamav-rest"
   REGISTRY_USER: ${{ secrets.DOCKER_USER }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
@@ -58,7 +57,7 @@ jobs:
         id: meta_dev
         uses: docker/metadata-action@v4
         with:
-          images: ajilaag/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_IMAGE }}
           tags: |
             type=raw,value={{date 'YYYYMMDD'}}
             type=raw,value=latest,enable={{is_default_branch}}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - "main"
 env:
-  REGISTRY_IMAGE: "${{ env.DOCKER_USER }}/clamav-rest"
+  REGISTRY_IMAGE: "$DOCKER_USER_VAR/clamav-rest"
   REGISTRY_USER: ${{ secrets.DOCKER_USER }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,6 +112,10 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=schedule,value={{date 'YYYYMMDD'}}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
       -
         name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -96,18 +96,17 @@ jobs:
     needs:
       - build
     steps:
-      -
-        name: Download digests
+      - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
-      -
-        name: Set up Docker Buildx
+      
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Docker meta
+      
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
         with:
@@ -116,14 +115,28 @@ jobs:
             type=schedule,value={{date 'YYYYMMDD'}}
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
-      -
-        name: Login to Docker Hub
+
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y%m%d')"
+
+
+      - name: Add version tag
+        - name: Set up Docker Buildx
+        id: tag_version
+          uses: docker/setup-buildx-action@v3
+        uses: laputansoft/github-tag-action@v4.6
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ steps.date.outputs.date }}
+
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-      -
-        name: Create manifest list and push
+     
+      - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
           docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,8 @@ on:
     branches:
       - "main"
 env:
-  REGISTRY_IMAGE: "$DOCKER_USER_VAR/clamav-rest"
-  REGISTRY_USER: $DOCKER_USER_VAR
+  REGISTRY_IMAGE: "${{ vars.DOCKER_USER_VAR }}/clamav-rest"
+  REGISTRY_USER: ${{ vars.DOCKER_USER_VAR }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,9 +46,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
+          # https://github.com/docker/metadata-action?tab=readme-ov-file#typeschedule
           tags: |
             type=schedule,value={{date 'YYYYMMDD'}}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -61,17 +63,6 @@ jobs:
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-
-      # - name: Build and push to DockerHub
-      #   id: container_metadata
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     context: .
-      #     platforms: ${{ matrix.platform }}
-      #     push: true
-      #     tags: ${{ steps.meta_dev.outputs.tags }}
-      #     labels: ${{ steps.meta_dev.outputs.labels }}
-      #     outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       
       - name: Build and push by digest
         id: build
@@ -96,17 +87,14 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+s
 
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y%m%d')"
-
-      - name: Add version tag
-        id: tag_version
-        uses: laputansoft/github-tag-action@v4.6
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ steps.date.outputs.date }}
+      # - name: Add version tag
+      #   id: tag_version
+      #   uses: laputansoft/github-tag-action@v4.6
+      #   with:
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      #     tag: ${{ steps.date.outputs.date }}
 
       # - name: Create a GitHub release
       #   uses: ncipollo/release-action@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,8 +9,8 @@ on:
     branches:
       - "main"
 env:
-  REGISTRY_IMAGE: "${{ env.DOCKER_USER_VAR }}/clamav-rest"
-  REGISTRY_USER: ${{ env.DOCKER_USER_VAR }}
+  REGISTRY_IMAGE: "$DOCKER_USER_VAR/clamav-rest"
+  REGISTRY_USER: $DOCKER_USER_VAR
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,10 @@
 name: Build, Push Container image to DockerHub
 
-# on:
-#   # workflow_dispatch:
-#   # schedule:
-#   #   - cron: '0 0 * * 6' # At 12:00 AM, only on Saturday
 on:
-  push:
-    branches:
-      - "main"
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 6' # At 12:00 AM, only on Saturday
+
 env:
   REGISTRY_IMAGE: "${{ vars.DOCKER_USER }}/clamav-rest"
   REGISTRY_USER: ${{ vars.DOCKER_USER }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,12 +20,14 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    matrix:
-      platform:
-        - linux/amd64
-        - linux/arm/v6
-        - linux/arm/v7
-        - linux/arm64
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm/v6
+          - linux/arm/v7
+          - linux/arm64
 
     outputs:
       image_digest: ${{ steps.container_metadata.outputs.digest }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           # https://github.com/docker/metadata-action?tab=readme-ov-file#typeschedule
           tags: |
             type=schedule,value={{date 'YYYYMMDD'}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            # type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
       - name: Set up QEMU

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 env:
   IMAGE_NAME: "clamav-rest"
 
-  REGISTRY_USER: ajilaag
+  REGISTRY_USER: ${{ secrets.DOCKER_USER }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
           # https://github.com/docker/metadata-action?tab=readme-ov-file#typeschedule
           tags: |
             type=schedule,value={{date 'YYYYMMDD'}}
-            # type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
             type=sha
 
       - name: Set up QEMU
@@ -71,7 +71,6 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ${{ steps.meta.outputs.tags }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ name: Build, Push Container image to DockerHub
 
 env:
   IMAGE_NAME: "clamav-rest"
-
+  REGISTRY_IMAGE: ${{ secrets.DOCKER_USER }}/${{ env.IMAGE_NAME }}
   REGISTRY_USER: ${{ secrets.DOCKER_USER }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Prepare
-      run: |
+    - run: |
         platform=${{ matrix.platform }}
         echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV  
     - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,10 @@ name: Build, Push Container image to DockerHub
 #   # workflow_dispatch:
 #   # schedule:
 #   #   - cron: '0 0 * * 6' # At 12:00 AM, only on Saturday
-
+on:
+  push:
+    branches:
+      - "main"
 env:
   IMAGE_NAME: "clamav-rest"
   REGISTRY_IMAGE: ${{ secrets.DOCKER_USER }}/${{ env.IMAGE_NAME }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
           body: ${{ steps.tag_version.outputs.changelog }}
 
 
-merge:
+  merge:
     runs-on: ubuntu-latest
     needs:
       - build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - "main"
 env:
-  REGISTRY_IMAGE: "${{ secrets.DOCKER_USER }}/clamav-rest"
+  REGISTRY_IMAGE: "${{ var.DOCKER_USER }}/clamav-rest"
   REGISTRY_USER: ${{ secrets.DOCKER_USER }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
           - linux/arm64
 
     outputs:
-      image_digest: ${{ steps.container_metadata.outputs.digest }}
+      # image_digest: ${{ steps.container_metadata.outputs.digest }}
       image_tags: ${{ steps.meta_dev.outputs.tags }}
 
     steps:
@@ -52,6 +52,16 @@ jobs:
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
+      
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+     
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}  
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta_dev
@@ -72,7 +82,20 @@ jobs:
           tags: ${{ steps.meta_dev.outputs.tags }}
           labels: ${{ steps.meta_dev.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-
+      
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"          
+      
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y%m%d')"
@@ -90,3 +113,42 @@ jobs:
           tag: ${{ steps.date.outputs.date }}
           name: Release ${{ steps.date.outputs.date }}
           body: ${{ steps.tag_version.outputs.changelog }}
+
+
+merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)          
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}         

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
       - "main"
 env:
   REGISTRY_IMAGE: "$DOCKER_USER_VAR/clamav-rest"
-  REGISTRY_USER: ${{ secrets.DOCKER_USER }}
+  REGISTRY_USER: $DOCKER_USER_VAR
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 permissions:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,8 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Export digest
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - "main"
 env:
-  REGISTRY_IMAGE: "${{ var.DOCKER_USER }}/clamav-rest"
+  REGISTRY_IMAGE: "${{ env.DOCKER_USER }}/clamav-rest"
   REGISTRY_USER: ${{ secrets.DOCKER_USER }}
   REGISTRY_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,9 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY_IMAGE }}
+          tags: |
+            type=schedule,value={{date 'YYYYMMDD'}}
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -58,15 +61,6 @@ jobs:
         with:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
- 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta_dev
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          tags: |
-            type=raw,value={{date 'YYYYMMDD'}}
-            type=raw,value=latest,enable={{is_default_branch}}
 
       # - name: Build and push to DockerHub
       #   id: container_metadata
@@ -86,10 +80,7 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          # https://github.com/docker/metadata-action?tab=readme-ov-file#typeschedule
-          tags: |
-            type=schedule,pattern={{date 'YYYYMMDD'}}
-            type=raw,value=latest,enable={{is_default_branch}}
+          tags: ${{ steps.meta.outputs.tags }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,17 +68,29 @@ jobs:
             type=raw,value={{date 'YYYYMMDD'}}
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build and push to DockerHub
-        id: container_metadata
+      # - name: Build and push to DockerHub
+      #   id: container_metadata
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     context: .
+      #     platforms: ${{ matrix.platform }}
+      #     push: true
+      #     tags: ${{ steps.meta_dev.outputs.tags }}
+      #     labels: ${{ steps.meta_dev.outputs.labels }}
+      #     outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          push: true
-          tags: ${{ steps.meta_dev.outputs.tags }}
-          labels: ${{ steps.meta_dev.outputs.labels }}
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            type=raw,value={{date 'YYYYMMDD'}}
+            type=raw,value=latest,enable={{is_default_branch}}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      
+
       - name: Export digest
         run: |
           mkdir -p /tmp/digests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
-s
+
 
       # - name: Add version tag
       #   id: tag_version


### PR DESCRIPTION
Adds multi-platform build & push to docker hub

You will need to add a user name var to your secrets. 

Tested images to https://hub.docker.com/r/kcirtapfromspace/clamav-rest/tags

Also updates dead action to the updated fork
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: laputansoft/github-tag-action@v4.6. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.