### PR TITLE
Security fix applied and documented

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine3.19.1 as build
+FROM golang:alpine3.19 as build
 
 # Update libraries
 RUN apk update upgrade 
@@ -10,7 +10,7 @@ WORKDIR /go/src
 ADD . /go/src/clamav-rest/
 RUN cd /go/src/clamav-rest && go mod download github.com/dutchcoders/go-clamd@latest && go mod init clamav-rest && go mod tidy && go mod vendor && go build -v
 
-FROM alpine:3.19.1
+FROM alpine:3.19
 
 # Copy compiled clamav-rest binary from build container to production container
 COPY --from=build /go/src/clamav-rest/clamav-rest /usr/bin/

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ As of May 2024, the releases are built for multiple architectures thanks to effo
 
 The additional endpoint `/version` is now available to check the `clamd` version and signature date. Thanks [pastral](https://github.com/pastral).
 
+Closed a security hole by upgrading our `Dockerfile` to the alpine base image version `3.19` thanks to [Marsup](https://github.com/Marsup).
+
 # Prerequisites
 
 This container doesn't do much on it's own unless you use an additional service or communicator to talk to it!


### PR DESCRIPTION
Dockerfile alpine image references changed to 3.19. Version 3.19.1 is not explicitly available for `golang`.