### PR TITLE
Change the NotifyClamd path to the new freshclam.conf path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ This is two in one docker image so it runs open source virus scanner ClamAV (htt
 
 # Updates
 
-As of October 15 2024, clamav handles database updates correctly thanks to [christianbumann](https://github.com/christianbumann).
+As of October 21 2024, freshclam notifies the correct .clamd.conf so the clamd is notified about updates and the correct version is returned now.
+This is an additional fix to latest fix from October 15 2024 which was not working. Thanks to [christianbumann](https://github.com/christianbumann).
+
+As of October 15 2024, clamav handles database updates correctly thanks to [christianbumann](https://github.com/christianbumann). Unfortunately the database still doesn't gets correctly updated.
 
 As of May 2024, the releases are built for multiple architectures thanks to efforts from [kcirtapfromspace](https://github.com/kcirtapfromspace) and support non-root read-only deployments thanks to [robaca](https://github.com/robaca).
 
@@ -151,11 +154,20 @@ Below is the complete list of available options that can be used to customize yo
 
 ## Shell Access
 
-For debugging and maintenance purposes you may want access the containers shell. 
+For debugging and maintenance purposes you may want access the containers shell.
 
 ```bash
 docker exec -it (whatever your container name is e.g. clamav-rest) /bin/sh
 ```
+
+Checking the version with the `clamscan` command requires to provide the custom database path.
+The default value is overwritten to `/clamav/data` in the `/clamav/etc/clamd.conf`, and the `clamav` service
+was started with this`/clamav/etc/clamd.conf` from the `entrypoint.sh`.
+
+```bash
+clamscan --database=/clamav/data --version
+```
+
 ## Prometheus
 
 [Prometheus metrics](https://prometheus.io/docs/guides/go-application/) were implemented, which can be retrieved as follows

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,9 +5,14 @@ mkdir -p /clamav/data
 mkdir -p /clamav/tmp
 cp /etc/clamav/* /clamav/etc/
 
+# Replace values in freshclam.conf
+sed -i 's/^#\?NotifyClamd .*$/NotifyClamd \/clamav\/etc\/clamd.conf/g' /clamav/etc/freshclam.conf
 sed -i 's/^#DatabaseDirectory .*$/DatabaseDirectory \/clamav\/data/g' /clamav/etc/freshclam.conf
 sed -i 's/^#TemporaryDirectory .*$/TemporaryDirectory \/clamav\/tmp/g' /clamav/etc/clamd.conf
 sed -i 's/^#DatabaseDirectory .*$/DatabaseDirectory \/clamav\/data/g' /clamav/etc/clamd.conf
+
+# Replace values with environment variables in freshclam.conf
+sed -i 's/^#\?Checks .*$/Checks '"$SIGNATURE_CHECKS"'/g' /clamav/etc/freshclam.conf
 
 # Replace values with environment variables in clamd.conf
 sed -i 's/^#MaxScanSize .*$/MaxScanSize '"$MAX_SCAN_SIZE"'/g' /clamav/etc/clamd.conf
@@ -30,9 +35,18 @@ if [ -z "$(ls -A /clamav/data)" ]; then
 fi
 
 (
-    freshclam --config-file=/clamav/etc/freshclam.conf --daemon --checks=$SIGNATURE_CHECKS &
+    freshclam --config-file=/clamav/etc/freshclam.conf --daemon &
     clamd --config-file=/clamav/etc/clamd.conf &
     /usr/bin/clamav-rest &
+    # Force reload the virus database through the clamd socket after 120s.
+    # Starting freshclam and clamd async ends up that a newer database version is loaded with
+    # freshclam, but the clamd still keep the old version existing before the update because 
+    # the socket from clamd is not yet ready to inform, what is indicated in the log
+    # during the startup of the container (WARNING: Clamd was NOT notified: Can't connect to clamd through /run/clamav/clamd.sock: No such file or directory).
+    # So only if a newer database version is available clamd will be notified next time, and this can take hours/days.
+    # Remarks: The socket port is configured in the .Dockerfile itself.
+    sleep 120s
+    echo RELOAD | nc 127.0.0.01 3310 &
 ) 2>&1 | tee -a /var/log/clamav/clamav.log
 
 pids=`jobs -p`


### PR DESCRIPTION
Freshclam now notifies the correct configuration about the database defininiton update.
Before this change the old path `/etc/clamav/clamd.conf` was is inside the `freshclam.conf`.

https://linux.die.net/man/5/freshclam.conf
NotifyClamd
Notify a running clamd(8) to reload its database after a download has occurred. The path for clamd.conf file must be provided. Default: The default is to not notify clamd. See clamd.conf(5)'s option SelfCheck for how clamd(8) handles database updates in this case.

Fixes #56