### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine3.19 as build
+FROM golang:alpine3.19 AS build
 
 # Update libraries
 RUN apk update && apk upgrade

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,9 +43,9 @@ RUN freshclam --quiet --no-dns
 COPY entrypoint.sh /usr/bin/
 
 RUN mkdir /clamav \
-    && chown -R clamav.clamav /clamav \
-    && chown -R clamav.clamav /var/log/clamav \
-    && chown -R clamav.clamav /run/clamav
+    && chown -R clamav:clamav /clamav \
+    && chown -R clamav:clamav /var/log/clamav \
+    && chown -R clamav:clamav /run/clamav
 
 ENV PORT=9000
 ENV SSL_PORT=9443


### PR DESCRIPTION
There was an issue during docker build with separation of user and group by using dot instead of colon after bumping the alpine image to 3.21. Switched to colon and now it works.