### PR TITLE
refactor: cleanup code to align with Go standards

### DIFF
--- a/clamrest.go
+++ b/clamrest.go
@@ -112,9 +112,6 @@ func scanPathHandler(w http.ResponseWriter, r *http.Request) {
 	for responseItem := range response {
 		eachResp := scanResponse{Status: responseItem.Status, Description: responseItem.Description}
 		eachResp.httpStatus = getHTTPStatusByClamStatus(responseItem)
-		if responseItem.Status == clamd.RES_FOUND {
-			noOfFoundViruses.Inc()
-		}
 		scanResults = append(scanResults, eachResp)
 	}
 


### PR DESCRIPTION
Cleanup source code to align with the go syntax standard like variable naming conventions for JSON responses and improved function naming consistency. It swaps out `fmt.Printf()` with manual timestamp additions for `log.Printf()` with automatic timestamp instead to make the log output more uniform and the code more readable.

Put the prometheus incrementer in the function which evaluates the response status code.

## Details

**Logging and Error Handling Improvements:**
- Replaced all `fmt.Println` and `fmt.Printf` statements with appropriate `log.Println` or `log.Printf` calls for consistent and structured logging throughout the codebase.

**Variable and Function Naming Consistency:**
- Standardized JSON variable names from `errJson`/`resJson` to `errJSON`/`resJSON` for clarity and Go naming convention alignment.
- Renamed `getHttpStatusByClamStatus` to `getHTTPStatusByClamStatus` to match Go's acronym capitalization conventions.

**Minor Code Cleanups:**
- Updated variable names for clarity, e.g., `version_string` to `versionStr`/`versionString`, and `version_values` to `versionValues`.
- Added a comment in `getCorsPolicy` to clarify the use of non-standard variable naming for environment variable compatibility.

**Behavioral Improvements:**
- Added a call to increment the `noOfFoundViruses` metric in `getHTTPStatusByClamStatus` when a virus is found, ensuring proper metric tracking.
- Improved error handling in `waitForClamD` by logging when ClamD does not respond to ping and handling errors more robustly.