### PR TITLE
change liveness and readiness probes to http/9000

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,13 +11,13 @@ WORKDIR /go/src
 ADD . /go/src/clamav-rest/
 RUN cd /go/src/clamav-rest && go mod tidy && go build -v
 
-FROM docker.io/python:3-alpine3.21
+FROM docker.io/python:3-alpine3.23
 
 # Copy compiled clamav-rest binary from build container to production container
 COPY --from=build /go/src/clamav-rest/clamav-rest /usr/bin/
 
 # Update & Install tzdata
-RUN apk update && apk upgrade && apk add --no-cache tzdata
+RUN apk update && apk upgrade --no-cache && apk add --no-cache tzdata
 
 # Enable Bash & logrotate
 RUN apk add bash logrotate

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ When a custom `freshclam.conf` is detected, the entrypoint skips all freshclam-r
 
 Your custom `freshclam.conf` must include these directives for the container to function correctly:
 
-```
+```text
 Foreground yes
 DatabaseDirectory /clamav/data
 NotifyClamd /clamav/etc/clamd.conf

--- a/clamrest.go
+++ b/clamrest.go
@@ -73,6 +73,7 @@ func home(w http.ResponseWriter, r *http.Request) {
 			log.Println(eErr)
 			return
 		}
+		w.WriteHeader(http.StatusServiceUnavailable)
 		fmt.Fprint(w, string(errJSON))
 		return
 	}

--- a/kubernetes_example/deployment.yaml
+++ b/kubernetes_example/deployment.yaml
@@ -57,6 +57,15 @@ spec:
             initialDelaySeconds: 45
             periodSeconds: 60
             failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 2
           # optional: mount TLS certs for HTTPS (port 9443)
           # volumeMounts:
           # - name: tls-certs
@@ -89,4 +98,3 @@ spec:
           operator: "Exists"
           effect: "NoExecute"
           tolerationSeconds: 30
-

--- a/kubernetes_example/deployment.yaml
+++ b/kubernetes_example/deployment.yaml
@@ -22,48 +22,49 @@ spec:
       nodeSelector:
         "beta.kubernetes.io/os": linux
       containers:
-      - name: clamav-rest-service
-        image: docker.io/ajilaag/clamav-rest:latest
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 9443
-        - containerPort: 9000
-        env:
-        - name: MAX_FILE_SIZE
-          valueFrom:
-            configMapKeyRef:
-              name: clamav-rest-service-config
-              key: MAX_FILE_SIZE
-        resources:
-          requests:
-            cpu: 100m
-            memory: 2000Mi
-          limits:
-            cpu: 200m
-            memory: 2500Mi
-        readinessProbe:
-          httpGet:
-            scheme: HTTP
-            path: /
-            port: 9000
-          initialDelaySeconds: 30
-          periodSeconds: 20
-          failureThreshold: 10
-        livenessProbe:
-          httpGet:
-            scheme: HTTP
-            path: /
-            port: 9000
-          initialDelaySeconds: 30
-          periodSeconds: 60
-        # optional: mount TLS certs for HTTPS (port 9443)
-        # volumeMounts:
-        # - name: tls-certs
-        #   mountPath: /etc/ssl/clamav-rest
-        #   readOnly: true
-        # optional: persisting the data directory
-        # - name: clamav-data
-        #   mountPath: /clamav/data
+        - name: clamav-rest-service
+          image: docker.io/ajilaag/clamav-rest:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 9443
+            - containerPort: 9000
+          env:
+            - name: MAX_FILE_SIZE
+              valueFrom:
+                configMapKeyRef:
+                  name: clamav-rest-service-config
+                  key: MAX_FILE_SIZE
+          resources:
+            requests:
+              cpu: 100m
+              memory: 2000Mi
+            limits:
+              cpu: 200m
+              memory: 2500Mi
+          startupProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            failureThreshold: 10
+          livenessProbe:
+            httpGet:
+              scheme: HTTP
+              path: /
+              port: 9000
+            initialDelaySeconds: 45
+            periodSeconds: 60
+            failureThreshold: 2
+          # optional: mount TLS certs for HTTPS (port 9443)
+          # volumeMounts:
+          # - name: tls-certs
+          #   mountPath: /etc/ssl/clamav-rest
+          #   readOnly: true
+          # optional: persisting the data directory
+          # - name: clamav-data
+          #   mountPath: /clamav/data
       # optional: mount TLS certs from a Kubernetes secret
       # kubectl create secret tls clamav-rest-tls --cert=server.crt --key=server.key -n clamav-rest
       # volumes:
@@ -80,11 +81,12 @@ spec:
       #   persistentVolumeClaim:
       #     claimName: my-pvc
       tolerations:
-      - key: "node.kubernetes.io/unreachable"
-        operator: "Exists"
-        effect: "NoExecute"
-        tolerationSeconds: 30
-      - key: "node.kubernetes.io/not-ready"
-        operator: "Exists"
-        effect: "NoExecute"
-        tolerationSeconds: 30
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 30
+

--- a/kubernetes_example/deployment.yaml
+++ b/kubernetes_example/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         imagePullPolicy: Always
         ports:
         - containerPort: 9443
+        - containerPort: 9000
         env:
         - name: MAX_FILE_SIZE
           valueFrom:
@@ -42,17 +43,17 @@ spec:
             memory: 2500Mi
         readinessProbe:
           httpGet:
-            scheme: HTTPS
+            scheme: HTTP
             path: /
-            port: 9443
+            port: 9000
           initialDelaySeconds: 30
           periodSeconds: 20
           failureThreshold: 10
         livenessProbe:
           httpGet:
-            scheme: HTTPS
+            scheme: HTTP
             path: /
-            port: 9443
+            port: 9000
           initialDelaySeconds: 30
           periodSeconds: 60
         # optional: mount TLS certs for HTTPS (port 9443)
@@ -86,4 +87,4 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: "Exists"
         effect: "NoExecute"
-        tolerationSeconds: 30          
+        tolerationSeconds: 30

--- a/kubernetes_example/deployment.yaml
+++ b/kubernetes_example/deployment.yaml
@@ -36,11 +36,11 @@ spec:
                   key: MAX_FILE_SIZE
           resources:
             requests:
-              cpu: 100m
+              cpu: 200m
               memory: 2000Mi
             limits:
-              cpu: 200m
-              memory: 2500Mi
+              cpu: 300m
+              memory: 3000Mi
           startupProbe:
             httpGet:
               scheme: HTTP


### PR DESCRIPTION
This PR fixes the liveness and readiness probe since HTTPS is now optional and no default TLS certificate is included.
#104 will be solved by this PR.