### PR TITLE
chore(compose): add healthchecks and remove version key

### DIFF
--- a/docker-compose-nonroot.yml
+++ b/docker-compose-nonroot.yml
@@ -13,7 +13,7 @@ services:
       - run-clamav:/run/clamav:rw
       - var-log-clamav:/var/log/clamav:rw
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:9000/ || exit 1"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9000/"]
       interval: 60s
       timeout: 2s
       retries: 2

--- a/docker-compose-nonroot.yml
+++ b/docker-compose-nonroot.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   clamav-rest:
     mem_reservation: "2G"
@@ -13,6 +12,14 @@ services:
       - clamav:/clamav:rw
       - run-clamav:/run/clamav:rw
       - var-log-clamav:/var/log/clamav:rw
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:9000/ || exit 1"]
+      interval: 60s
+      timeout: 2s
+      retries: 2
+      # ClamAV and the virus DB load can take a while on cold start, so allow extra startup time
+      # before Compose starts counting healthcheck failures against the container.
+      start_period: 210s
 volumes:
   clamav:
   run-clamav:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,3 +8,11 @@ services:
     ports:
       - "9000:9000"
       - "9443:9443"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:9000/ || exit 1"]
+      interval: 60s
+      timeout: 2s
+      retries: 2
+      # ClamAV and the virus DB load can take a while on cold start, so allow extra startup time
+      # before Compose starts counting healthcheck failures against the container.
+      start_period: 210s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,7 +9,7 @@ services:
       - "9000:9000"
       - "9443:9443"
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:9000/ || exit 1"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9000/"]
       interval: 60s
       timeout: 2s
       retries: 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   clamav-rest:
     mem_reservation: 262144000
@@ -7,3 +6,11 @@ services:
     ports:
       - "9000:9000"
       - "9443:9443"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:9000/ || exit 1"]
+      interval: 60s
+      timeout: 2s
+      retries: 2
+      # ClamAV and the virus DB load can take a while on cold start, so allow extra startup time
+      # before Compose starts counting healthcheck failures against the container.
+      start_period: 210s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "9000:9000"
       - "9443:9443"
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:9000/ || exit 1"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:9000/"]
       interval: 60s
       timeout: 2s
       retries: 2


### PR DESCRIPTION
## Summary
- remove deprecated Compose `version` keys from the compose manifests
- add HTTP healthchecks on `/` for the main, nonroot, and test compose services
- document why `start_period` is extended to cover ClamAV cold starts and virus DB loading

## Verification
- docker compose -f docker-compose.yml config
- docker compose -f docker-compose-nonroot.yml config
- docker compose -f docker-compose.test.yml config
- docker compose -f docker-compose.yml up -d
- docker inspect --format "{{json .State.Health}}" clamav-rest-clamav-rest-1
- docker exec clamav-rest-clamav-rest-1 wget -S -O /dev/null http://localhost:9000/
- docker compose -f docker-compose.yml down