### PR TITLE
fix(kubernetes): correct monitoring selectors

### DIFF
--- a/kubernetes_example/metrics-service.yaml
+++ b/kubernetes_example/metrics-service.yaml
@@ -33,8 +33,8 @@ spec:
     tlsConfig:
       insecureSkipVerify: true
   namespaceSelector:
-    matchNames: 
-    - clamav-rest-service
+    matchNames:
+    - clamav-rest
   selector:
     matchLabels:
       app: clamav-rest-service

--- a/kubernetes_example/networkpolicy.yaml
+++ b/kubernetes_example/networkpolicy.yaml
@@ -24,10 +24,10 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: monitoring
-    - podSelector:
+          kubernetes.io/metadata.name: monitoring
+      podSelector:
         matchLabels:
           app: prometheus
     ports:
     - protocol: TCP
-      port: 9443      
+      port: 9443


### PR DESCRIPTION
## Summary

- require Prometheus ingress sources to match both the `monitoring` namespace and the Prometheus pod label
- use Kubernetes' automatic `kubernetes.io/metadata.name` namespace label
- make the ServiceMonitor discover the metrics Service in the `clamav-rest` namespace

## Root cause

The namespace and pod selectors were separate `from` list entries, which makes them alternatives instead of a combined restriction. The ServiceMonitor also used the Service name where a namespace name was required.

## Impact

The policy no longer grants port 9443 access to every pod in the monitoring namespace or to matching pods in the application namespace. Prometheus service discovery now targets the namespace that actually contains the metrics Service.

## Validation

- `yamllint` passed for both changed manifests
- `yq` parsed all YAML documents successfully
- selector assertions verified one ingress peer containing both selectors and the corrected ServiceMonitor namespace
- `git diff --check` passed

Cluster-backed `kubectl` validation was not run because no Kubernetes API context is configured in this checkout.

## Related work

PR #112 moves the Prometheus policy into an optional package and should retain this combined selector structure when rebased.
